### PR TITLE
Utterances github issues comments 기능 추가

### DIFF
--- a/src/components/Utterances.tsx
+++ b/src/components/Utterances.tsx
@@ -1,0 +1,34 @@
+import React, { useEffect, useRef } from 'react';
+
+const Utterances = () => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  const utterancesSettings = {
+    src: 'https://utteranc.es/client.js',
+    repo: 'LEEHYUNHO2001/ayaanlog',
+    'issue-term': 'url',
+    label: 'utterances',
+    theme: 'github-light',
+    crossorigin: 'anonymous',
+    async: 'true',
+  };
+
+  useEffect(() => {
+    const isRender = document.querySelector('.utterances');
+    if (!isRender) {
+      if (ref.current !== null) {
+        const utterances = document.createElement('script');
+
+        Object.entries(utterancesSettings).forEach(([key, value]) => {
+          utterances.setAttribute(key, value);
+        });
+
+        ref.current.appendChild(utterances);
+      }
+    }
+  }, []);
+
+  return <div ref={ref} />;
+};
+
+export default Utterances;

--- a/src/pages/[category]/[title].tsx
+++ b/src/pages/[category]/[title].tsx
@@ -1,0 +1,13 @@
+import dynamic from 'next/dynamic';
+
+const Utterances = dynamic(() => import('@/components/Utterances'), {
+  ssr: false,
+});
+
+const TitlePage = () => (
+  <div>
+    <Utterances />
+  </div>
+);
+
+export default TitlePage;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,3 @@
-import type { NextPage } from 'next';
-
-const Home: NextPage = () => <div>Home</div>;
+const Home = () => <section>Home</section>;
 
 export default Home;


### PR DESCRIPTION
<!-- 작업 내용은 최대한 자세하게 입력해주시기 바랍니다. -->

# 1. 작업 내용

- Github의 issues를 이용한 Comment 기능을 구현하기 위해 Utterances 사용합니다.
- 글의 상세 페이지는 `카테고리/타이틀` 경로로 보내주기 위해 동적 라우팅을 사용하고 있습니다.

<!-- 전달하고 싶은 사항이 있다면 공유해주세요. -->

# 2. 전달 사항

- 2번 랜더링 되는 문제점이 있습니다.

<!-- ex) AuthStore의 함수들이 각자의 역할을 다했는지? 검토하며 리뷰해주세요. -->

# 3. 코드리뷰를 부탁할 부분
